### PR TITLE
Fix for forced libiconv in non Visual Studio environments

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -197,8 +197,6 @@ class GdalConan(ConanFile):
             del self.options.with_null
             del self.options.with_zlib # zlib and png are always used in nmake build,
             del self.options.with_png  # and it's not trivial to fix
-        else:
-            del self.options.with_libiconv
         if self.options.get_safe("with_libdeflate") and not self.options.get_safe("with_zlib", True):
             raise ConanInvalidConfiguration("gdal:with_libdeflate=True requires gdal:with_zlib=True")
         self._strict_options_requirements()
@@ -617,7 +615,10 @@ class GdalConan(ConanFile):
         args.append("--with-libz={}".format("yes" if self.options.with_zlib else "no"))
         if self._has_with_libdeflate_option:
             args.append("--with-libdeflate={}".format("yes" if self.options.with_libdeflate else "no"))
-        args.append("--with-libiconv-prefix={}".format(tools.unix_path(self.deps_cpp_info["libiconv"].rootpath)))
+        if self.options.with_libiconv:
+            args.append("--with-libiconv-prefix={}".format(tools.unix_path(self.deps_cpp_info["libiconv"].rootpath)))
+        else:
+            args.append("--without-libiconv-prefix")
         args.append("--with-liblzma=no") # always disabled: liblzma is an optional transitive dependency of gdal (through libtiff).
         args.append("--with-zstd={}".format("yes" if self.options.get_safe("with_zstd") else "no")) # Optional direct dependency of gdal only if lerc lib enabled
         # Drivers:


### PR DESCRIPTION
Hi @SpaceIm 

First of all thanks for your support making gdal available through conan. We are experiencing some licensing issues due to the fact that the conan recipe is not honoring the `--with-libiconv ` option. I'm not sure what is the reason for disabling this option in non VisualStudio builds. This PR addresses the problem we have, but wondering why it was done in the first place. 

Thanks a lot.

Commit message:
The problem with forcing libiconv (LGPL 2.1) is mainly a matter of licensing, making impossible to statically build gdal (MIT license) in enviroments where LGPL is not permitted. The proposed fix honors the option to disable libiconv.

